### PR TITLE
fix: correct queue endpoint names

### DIFF
--- a/apps/web/src/app/(protected)/queue/page.tsx
+++ b/apps/web/src/app/(protected)/queue/page.tsx
@@ -161,8 +161,8 @@ export default function QueuePage() {
     try {
       // Try to fetch from API
       const [statusResponse, predictionsResponse] = await Promise.all([
-        apiClient.get<QueueStatusData>(`/queue/${selectedTerminal}/status`),
-        apiClient.get<HourlyPrediction[]>(`/queue/${selectedTerminal}/predictions`),
+        apiClient.get<QueueStatusData>(`/queue/${selectedTerminal}/current`),
+        apiClient.get<HourlyPrediction[]>(`/queue/${selectedTerminal}/timeline`),
       ]);
 
       const newStatus = statusResponse.data;


### PR DESCRIPTION
Closes #2

Updates frontend to call correct backend endpoint names:
- `/status` → `/current`
- `/predictions` → `/timeline`

🤖 Generated with [Claude Code](https://claude.com/claude-code)