### PR TITLE
fix: queue predictions vary by date

### DIFF
--- a/packages/autoclaim/src/api/handlers/queue.handler.ts
+++ b/packages/autoclaim/src/api/handlers/queue.handler.ts
@@ -130,7 +130,7 @@ export async function registerQueueRoutes(app: FastifyInstance): Promise<void> {
       reply: FastifyReply
     ) => {
       const { terminal } = request.params;
-      const hours = request.query.hours ?? 12;
+      const { hours = 12, date } = request.query;
 
       if (!terminalConfig[terminal as Terminal]) {
         throw ApiException.notFound(
@@ -139,7 +139,7 @@ export async function registerQueueRoutes(app: FastifyInstance): Promise<void> {
         );
       }
 
-      const startTime = new Date();
+      const startTime = date ? new Date(date) : new Date();
       const predictions = predictQueueTimeline(terminal as Terminal, startTime, hours);
 
       const response: TimelinePredictionResponse[] = predictions.map((prediction, index) => {

--- a/packages/autoclaim/src/api/schemas/queue.schema.ts
+++ b/packages/autoclaim/src/api/schemas/queue.schema.ts
@@ -61,6 +61,7 @@ export type TerminalParams = Static<typeof TerminalParamsSchema>;
  */
 export const TimelineQuerySchema = Type.Object({
   hours: Type.Optional(Type.Integer({ minimum: 1, maximum: 48, default: 12 })),
+  date: Type.Optional(Type.String({ format: 'date' })),
 });
 
 export type TimelineQuery = Static<typeof TimelineQuerySchema>;


### PR DESCRIPTION
## Summary
- Adds date query parameter to timeline endpoint
- Predictions now vary by week number
- Frontend passes selected date to API

## Test plan
- [ ] Verify timeline endpoint accepts `date` query param
- [ ] Verify predictions differ between weeks (week 1 vs week 2)
- [ ] Verify frontend date picker triggers API refetch

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)