### PR TITLE
fix: include test files in euroqueue tsconfig

### DIFF
--- a/packages/euroqueue/src/__tests__/prediction.service.test.ts
+++ b/packages/euroqueue/src/__tests__/prediction.service.test.ts
@@ -5,7 +5,6 @@ import {
   getBestArrivalTime,
   type PredictionContext,
 } from '../services/prediction.service.js';
-import type { Terminal } from '../types.js';
 
 describe('Prediction Service', () => {
   describe('predictQueueTime', () => {

--- a/packages/euroqueue/tsconfig.json
+++ b/packages/euroqueue/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Closes #7

## Summary
- Removes `**/*.test.ts` from tsconfig exclude array so ESLint can parse test files
- Removes unused `Terminal` import from test file (was causing TS6133 error)

## Test plan
- [x] Verified `pnpm build` passes for euroqueue package
- [x] Verified `pnpm lint` passes for euroqueue package

🤖 Generated with [Claude Code](https://claude.com/claude-code)